### PR TITLE
Switch mailer to use BaseMailer for inheriting and convention.

### DIFF
--- a/app/mailers/spree/stock_emails_mailer.rb
+++ b/app/mailers/spree/stock_emails_mailer.rb
@@ -1,5 +1,5 @@
 module Spree
-  class StockEmailsMailer < ActionMailer::Base
+  class StockEmailsMailer < BaseMailer
     default from: Spree::StockEmailConfig::Config.email_from
 
     def stock_email(stock_email)


### PR DESCRIPTION
Quick fix so StockEmailsMailer uses Spree's BaseMailer
