### PR TITLE
Enable stock emails when requested against product master

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here is a basic partial:
   <% end %>
 <% else %>
   <%= form_for :stock_email, url: stock_emails_path do |form| %>
-    <%= form.hidden_field :product, value: @product.id %>
+    <%= form.hidden_field :variant, value: @product.master.id %>
     <%= form.label :email, "Your email address" %>
     <%= form.text_field :email %>
     <%= button_tag class: 'button', type: :submit do %>

--- a/app/models/spree/stock_email.rb
+++ b/app/models/spree/stock_email.rb
@@ -15,7 +15,7 @@ class Spree::StockEmail < ActiveRecord::Base
   end
 
   def self.notify(variant)
-    where(sent_at: nil, variant_id: variant.id).each { |e| e.notify }
+    where(sent_at: nil, variant_id: [variant.id, variant.product.master.id]).each { |e| e.notify }
   end
 
   def email_exists?


### PR DESCRIPTION
Allow stock item replenishment to also trigger stock notifications on the master variant to handle case where customer wishes to be notified when any of the product variants are back in stock.

I also tweaked the readme since the 3-0 branch example partial was still using product instead of variant.
